### PR TITLE
Harden Redis store semantics and align CI/tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: "*"
 
 jobs:
   check_format:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
-    continue-on-error: false
     steps:
       - name: Download source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Install shards
@@ -23,17 +19,15 @@ jobs:
         run: crystal tool format --check
       - name: Lint
         run: ./bin/ameba
+      - name: Build shard entrypoint
+        run: crystal build src/lucky_cache_redis_store.cr
+
   specs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        crystal_version: [latest]
-        include:
-          - os: ubuntu-latest
-            crystal_version: 1.4.0
-    runs-on: ${{ matrix.os }}
-    continue-on-error: false
+        crystal_version: ["1.16.3", latest]
+    runs-on: ubuntu-latest
     services:
       redis:
         image: redis:7-alpine
@@ -45,7 +39,7 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1
@@ -17,7 +19,7 @@ jobs:
       - name: "Generate docs"
         run: crystal docs
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Redis store supports the following types:
 - Basic types: `String`, `Int32`, `Int64`, `Float64`, `Bool`, `Time`, `UUID`, `JSON::Any`
 - Arrays of basic types: `Array(String)`, `Array(Int32)`, `Array(Int64)`, `Array(Float64)`, `Array(Bool)`
 
-**Note:** Custom objects that include `LuckyCache::Cachable` are not supported by RedisStore due to serialization limitations. Use MemoryStore for caching custom objects.
+**Note:** Custom objects that include `LuckyCache::Cacheable` are not supported by RedisStore due to serialization limitations. Use MemoryStore for caching custom objects.
 
 ### Workaround for Custom Objects
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ A Redis storage backend for [LuckyCache](https://github.com/luckyframework/lucky
 
    ```yaml
    dependencies:
-     lucky_cache:
-       github: luckyframework/lucky_cache
      lucky_cache_redis_store:
        github: luckyframework/lucky_cache_redis_store
    ```
@@ -19,9 +17,7 @@ A Redis storage backend for [LuckyCache](https://github.com/luckyframework/lucky
 ## Usage
 
 ```crystal
-require "lucky_cache"
 require "lucky_cache_redis_store"
-require "redis"
 
 LuckyCache.configure do |settings|
   settings.storage = LuckyCache::RedisStore.new(
@@ -58,6 +54,19 @@ cache.delete("my_key")
 cache.flush
 ```
 
+## Expiration Semantics
+
+- `expires_in` is stored with millisecond precision.
+- TTL values must be at least `1.millisecond`.
+- `0.seconds`, negative durations, and positive durations below `1.millisecond` raise `ArgumentError`.
+- `read` restores cache items with their original TTL metadata and the correct absolute expiration time.
+
+## Prefix Operations
+
+- `flush` removes only keys that match the store's configured prefix.
+- `size` counts only keys that match the configured prefix.
+- Both operations iterate Redis with `SCAN`, not `KEYS`, so they remain safer on larger keyspaces.
+
 ### Supported Types
 
 The Redis store supports the following types:
@@ -75,7 +84,10 @@ You can cache JSON representations of your objects:
 # cache.write("user:123") { User.new("test@example.com") } # This will raise an error
 
 # Cache a JSON representation
-user_data = {"id" => 123, "email" => "test@example.com"}
+user_data = {
+  "id" => JSON::Any.new(123_i64),
+  "email" => JSON::Any.new("test@example.com"),
+}
 cache.write("user:123") { JSON::Any.new(user_data) }
 
 # Retrieve and reconstruct
@@ -87,14 +99,16 @@ user = User.new(cached_data["email"].as_s)
 
 To run the tests:
 
-1. Make sure Redis is running locally on the default port (6379)
+1. Make sure Redis is running locally on the default port (`6379`)
 2. Run `crystal spec`
 
 The test suite includes tests for:
 - Basic type caching
 - Array type caching
-- Expiration functionality
-- Key deletion and cache flushing
+- Millisecond TTL handling and TTL validation
+- Expiration correctness after Redis deserialization
+- Key deletion, prefix-scoped flushing, and prefix-scoped sizing
+- Standalone shard loading
 - Custom prefix support
 - Error handling for non-serializable types
 

--- a/shard.yml
+++ b/shard.yml
@@ -20,3 +20,4 @@ development_dependencies:
     version: ~> 1.6.4
   timecop:
     github: crystal-community/timecop.cr
+    version: ~> 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: lucky_cache_redis_store
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: '>= 1.14.1'
+crystal: ">= 1.16.3"
 
 license: MIT
 
@@ -17,6 +17,6 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    version: ~> 1.6.4
   timecop:
     github: crystal-community/timecop.cr

--- a/spec/lucky_cache_redis_store/redis_store_spec.cr
+++ b/spec/lucky_cache_redis_store/redis_store_spec.cr
@@ -49,7 +49,7 @@ describe LuckyCache::RedisStore do
   describe "#fetch" do
     it "raises an error for custom cachable objects" do
       with_cache do |cache, _|
-        expect_raises(ArgumentError, "RedisStore cannot serialize custom Cachable objects") do
+        expect_raises(ArgumentError, "RedisStore cannot serialize custom Cacheable objects") do
           cache.write("user") { User.new("test@example.com") }
         end
       end
@@ -280,7 +280,7 @@ describe LuckyCache::RedisStore do
 end
 
 class User
-  include LuckyCache::Cachable
+  include LuckyCache::Cacheable
   property email : String
 
   def initialize(@email : String)

--- a/spec/lucky_cache_redis_store/redis_store_spec.cr
+++ b/spec/lucky_cache_redis_store/redis_store_spec.cr
@@ -1,252 +1,284 @@
 require "../spec_helper"
 require "redis"
 
+private def project_root : String
+  File.expand_path("../..", __DIR__)
+end
+
+private def with_cache(prefix = "spec:#{UUID.random}:", &)
+  redis_client = Redis::Client.new
+  cache = LuckyCache::RedisStore.new(redis_client, prefix: prefix)
+  cache.flush
+
+  begin
+    yield cache, redis_client
+  ensure
+    cache.flush
+  end
+end
+
+private def read_item(cache : LuckyCache::RedisStore, key : String) : LuckyCache::CacheItem
+  cache.read(key) || raise "Expected cache item for #{key}"
+end
+
 describe LuckyCache::RedisStore do
-  describe "#fetch" do
-    it "raises error for custom cachable objects" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+  describe "entrypoint" do
+    it "loads standalone without requiring lucky_cache first" do
+      output = IO::Memory.new
+      error = IO::Memory.new
+      binary_path = "/tmp/lucky_cache_redis_store_entrypoint_check"
 
-      expect_raises(ArgumentError, "RedisStore cannot serialize custom Cachable objects") do
-        cache.write("user") { User.new("test@example.com") }
+      begin
+        status = Process.run(
+          "crystal",
+          ["build", "src/lucky_cache_redis_store.cr", "-o", binary_path],
+          chdir: project_root,
+          output: output,
+          error: error
+        )
+
+        raise "standalone require failed\nstdout:\n#{output}\nstderr:\n#{error}" unless status.success?
+
+        File.exists?(binary_path).should eq(true)
+      ensure
+        File.delete(binary_path) if File.exists?(binary_path)
       end
+    end
+  end
 
-      cache.flush
+  describe "#fetch" do
+    it "raises an error for custom cachable objects" do
+      with_cache do |cache, _|
+        expect_raises(ArgumentError, "RedisStore cannot serialize custom Cachable objects") do
+          cache.write("user") { User.new("test@example.com") }
+        end
+      end
     end
 
     it "caches basic types" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      str = cache.fetch("string:key", as: String) { "test" }
-      int = cache.fetch("int:key", as: Int64) { 0_i64 }
-      bul = cache.fetch("bool:key", as: Bool) { false }
-      tym = cache.fetch("time:key", as: Time) { Time.local(1999, 10, 31, 18, 30) }
-
-      str.should eq("test")
-      int.should eq(0_i64)
-      bul.should eq(false)
-      tym.should eq(Time.local(1999, 10, 31, 18, 30))
-
-      cache.flush
+      with_cache do |cache, _|
+        cache.fetch("string:key", as: String) { "test" }.should eq("test")
+        cache.fetch("int:key", as: Int64) { 0_i64 }.should eq(0_i64)
+        cache.fetch("bool:key", as: Bool) { false }.should eq(false)
+        cache.fetch("time:key", as: Time) { Time.local(1999, 10, 31, 18, 30) }.should eq(Time.local(1999, 10, 31, 18, 30))
+      end
     end
 
     it "caches arrays of basic types" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      str_array = cache.fetch("strings", as: Array(String)) { ["hello", "world"] }
-      int_array = cache.fetch("ints", as: Array(Int32)) { [1, 2, 3] }
-      bool_array = cache.fetch("bools", as: Array(Bool)) { [true, false, true] }
-
-      str_array.should eq(["hello", "world"])
-      int_array.should eq([1, 2, 3])
-      bool_array.should eq([true, false, true])
-
-      cache.flush
+      with_cache do |cache, _|
+        cache.fetch("strings", as: Array(String)) { ["hello", "world"] }.should eq(["hello", "world"])
+        cache.fetch("ints", as: Array(Int32)) { [1, 2, 3] }.should eq([1, 2, 3])
+        cache.fetch("bools", as: Array(Bool)) { [true, false, true] }.should eq([true, false, true])
+      end
     end
 
-    it "expires at the specified time" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+    it "supports sub-second expirations" do
+      with_cache do |cache, _|
+        cache.fetch("coupon", expires_in: 750.milliseconds, as: UUID) { UUID.random }
 
-      Timecop.freeze(Time.local(2042, 3, 17, 21, 49)) do
-        cache.fetch("coupon", expires_in: 2.seconds, as: UUID) do
-          UUID.random
-        end
-        cache.read("coupon").not_nil!.expired?.should eq(false)
-
-        sleep 3.seconds
-        cache.read("coupon").should eq(nil)
+        cache.read("coupon").should_not be_nil
+        sleep 900.milliseconds
+        cache.read("coupon").should be_nil
       end
-
-      cache.flush
     end
   end
 
   describe "#read" do
     it "returns nil when no key is found" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      cache.read("key").should eq(nil)
-
-      cache.flush
+      with_cache do |cache, _|
+        cache.read("missing").should be_nil
+      end
     end
 
     it "returns nil when the item is expired" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+      with_cache do |cache, _|
+        cache.write("key", expires_in: 1.second) { "some data" }
 
-      cache.write("key", expires_in: 1.second) { "some data" }
-      sleep 2.seconds
-      cache.read("key").should eq(nil)
-
-      cache.flush
-    end
-  end
-
-  describe "#delete" do
-    it "returns nil when no item exists" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      cache.delete("key").should eq(nil)
-
-      cache.flush
+        sleep 1200.milliseconds
+        cache.read("key").should be_nil
+      end
     end
 
-    it "deletes the value from cache" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+    it "preserves the original ttl and absolute expiration after deserialization" do
+      with_cache do |cache, _|
+        cache.write("key", expires_in: 2.seconds) { "some data" }
 
-      cache.write("key") { 123 }
-      cache.read("key").should_not be_nil
-      cache.delete("key")
-      cache.read("key").should be_nil
+        sleep 1.second
+        item = read_item(cache, "key")
+        item.expires_in.should eq(2.seconds)
+        item.expired?.should eq(false)
 
-      cache.flush
-    end
-  end
-
-  describe "#flush" do
-    it "resets all of the cache" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      cache.write("numbers") { 123 }
-      cache.write("letters") { "abc" }
-      cache.write("false") { true }
-      cache.read("numbers").should_not be_nil
-      cache.read("letters").should_not be_nil
-      cache.read("false").should_not be_nil
-
-      cache.flush
-
-      cache.read("numbers").should be_nil
-      cache.read("letters").should be_nil
-      cache.read("false").should be_nil
-    end
-  end
-
-  describe "#size" do
-    it "returns the total number of items in the cache" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
-
-      cache.size.should eq(0)
-
-      cache.write("numbers") { 123 }
-      cache.write("letters") { "abc" }
-      cache.size.should eq(2)
-
-      cache.flush
-      cache.size.should eq(0)
-    end
-  end
-
-  describe "with custom prefix" do
-    it "uses the custom prefix for keys" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client, prefix: "myapp:")
-      cache.flush
-
-      cache.write("test") { "value" }
-
-      redis_client.keys("myapp:*").size.should eq(1)
-      redis_client.get("myapp:test").should_not be_nil
-
-      cache.flush
+        sleep 1200.milliseconds
+        item.expired?.should eq(true)
+        cache.read("key").should be_nil
+      end
     end
   end
 
   describe "#write" do
     it "supports JSON::Any values" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+      with_cache do |cache, _|
+        json = JSON.parse(%({"name": "test", "count": 42}))
+        cache.write("json_data") { json }
 
-      json = JSON.parse(%({"name": "test", "count": 42}))
-      cache.write("json_data") { json }
-
-      result = cache.read("json_data")
-      result.should_not be_nil
-      result.not_nil!.value.as(JSON::Any)["name"].as_s.should eq("test")
-      result.not_nil!.value.as(JSON::Any)["count"].as_i.should eq(42)
-
-      cache.flush
+        result = read_item(cache, "json_data").value.as(JSON::Any)
+        result["name"].as_s.should eq("test")
+        result["count"].as_i.should eq(42)
+      end
     end
 
     it "stores UUID values" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+      with_cache do |cache, _|
+        uuid = UUID.random
+        cache.write("uuid_key") { uuid }
 
-      uuid = UUID.random
-      cache.write("uuid_key") { uuid }
-
-      result = cache.read("uuid_key")
-      result.should_not be_nil
-      result.not_nil!.value.as(UUID).should eq(uuid)
-
-      cache.flush
+        read_item(cache, "uuid_key").value.as(UUID).should eq(uuid)
+      end
     end
 
     it "stores arrays of basic types" do
+      with_cache do |cache, _|
+        str_array = ["hello", "world"]
+        int_array = [1, 2, 3]
+        bool_array = [true, false, true]
+
+        cache.write("strings") { str_array }
+        cache.write("ints") { int_array }
+        cache.write("bools") { bool_array }
+
+        read_item(cache, "strings").value.as(Array(String)).should eq(str_array)
+        read_item(cache, "ints").value.as(Array(Int32)).should eq(int_array)
+        read_item(cache, "bools").value.as(Array(Bool)).should eq(bool_array)
+      end
+    end
+
+    it "rejects ttl values below one millisecond" do
+      with_cache do |cache, _|
+        expect_raises(ArgumentError, "expires_in must be at least 1 millisecond") do
+          cache.write("tiny", expires_in: 500.microseconds) { "value" }
+        end
+      end
+    end
+
+    it "rejects zero ttl values" do
+      with_cache do |cache, _|
+        expect_raises(ArgumentError, "expires_in must be at least 1 millisecond") do
+          cache.write("zero", expires_in: 0.seconds) { "value" }
+        end
+      end
+    end
+
+    it "rejects negative ttl values" do
+      with_cache do |cache, _|
+        expect_raises(ArgumentError, "expires_in must be at least 1 millisecond") do
+          cache.write("negative", expires_in: -1.second) { "value" }
+        end
+      end
+    end
+  end
+
+  describe "#delete" do
+    it "returns nil when no item exists" do
+      with_cache do |cache, _|
+        cache.delete("key").should be_nil
+      end
+    end
+
+    it "deletes the value from cache" do
+      with_cache do |cache, _|
+        cache.write("key") { 123 }
+        cache.read("key").should_not be_nil
+
+        cache.delete("key").should eq(1)
+        cache.read("key").should be_nil
+      end
+    end
+  end
+
+  describe "#flush" do
+    it "removes only keys for the configured prefix" do
       redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+      main_cache = LuckyCache::RedisStore.new(redis_client, prefix: "spec:flush:main:")
+      other_cache = LuckyCache::RedisStore.new(redis_client, prefix: "spec:flush:other:")
 
-      str_array = ["hello", "world"]
-      int_array = [1, 2, 3]
-      bool_array = [true, false, true]
+      begin
+        main_cache.flush
+        other_cache.flush
+        redis_client.del("spec:flush:outside")
 
-      cache.write("strings") { str_array }
-      cache.write("ints") { int_array }
-      cache.write("bools") { bool_array }
+        main_cache.write("numbers") { 123 }
+        main_cache.write("letters") { "abc" }
+        other_cache.write("letters") { "keep me" }
+        redis_client.set("spec:flush:outside", "keep me")
 
-      cache.read("strings").not_nil!.value.as(Array(String)).should eq(str_array)
-      cache.read("ints").not_nil!.value.as(Array(Int32)).should eq(int_array)
-      cache.read("bools").not_nil!.value.as(Array(Bool)).should eq(bool_array)
+        main_cache.flush
 
-      cache.flush
+        main_cache.read("numbers").should be_nil
+        main_cache.read("letters").should be_nil
+        read_item(other_cache, "letters").value.as(String).should eq("keep me")
+        redis_client.get("spec:flush:outside").should eq("keep me")
+      ensure
+        main_cache.flush
+        other_cache.flush
+        redis_client.del("spec:flush:outside")
+      end
+    end
+  end
+
+  describe "#size" do
+    it "counts only items for the configured prefix" do
+      redis_client = Redis::Client.new
+      main_cache = LuckyCache::RedisStore.new(redis_client, prefix: "spec:size:main:")
+      other_cache = LuckyCache::RedisStore.new(redis_client, prefix: "spec:size:other:")
+
+      begin
+        main_cache.flush
+        other_cache.flush
+        redis_client.del("spec:size:outside")
+
+        main_cache.size.should eq(0)
+
+        main_cache.write("numbers") { 123 }
+        main_cache.write("letters") { "abc" }
+        other_cache.write("letters") { "elsewhere" }
+        redis_client.set("spec:size:outside", "value")
+
+        main_cache.size.should eq(2)
+        other_cache.size.should eq(1)
+      ensure
+        main_cache.flush
+        other_cache.flush
+        redis_client.del("spec:size:outside")
+      end
+    end
+  end
+
+  describe "with custom prefix" do
+    it "uses the custom prefix for keys" do
+      with_cache("myapp:") do |cache, redis_client|
+        cache.write("test") { "value" }
+
+        redis_client.get("myapp:test").should_not be_nil
+      end
     end
   end
 
   describe "workaround for custom objects" do
     it "can cache JSON representations of custom objects" do
-      redis_client = Redis::Client.new
-      cache = LuckyCache::RedisStore.new(redis_client)
-      cache.flush
+      with_cache do |cache, _|
+        user_data = {
+          "email" => JSON::Any.new("fred@email.net"),
+        }
 
-      # Instead of caching the User object directly, cache its JSON representation
-      user_data = Hash(String, JSON::Any).new
-      user_data["email"] = JSON::Any.new("fred@email.net")
-      cache.write("user:fred") { JSON::Any.new(user_data) }
+        cache.write("user:fred") { JSON::Any.new(user_data) }
 
-      # Retrieve and reconstruct
-      cached_data = cache.read("user:fred").not_nil!.value.as(JSON::Any)
-      cached_data["email"].as_s.should eq("fred@email.net")
-
-      # You can reconstruct the User object from the JSON data
-      # user = User.new(cached_data["email"].as_s)
-
-      cache.flush
+        cached_data = read_item(cache, "user:fred").value.as(JSON::Any)
+        cached_data["email"].as_s.should eq("fred@email.net")
+      end
     end
   end
 end
 
-# Define User class only for error testing
 class User
   include LuckyCache::Cachable
   property email : String

--- a/src/lucky_cache_redis_store.cr
+++ b/src/lucky_cache_redis_store.cr
@@ -1,5 +1,6 @@
+require "lucky_cache"
 require "./lucky_cache_redis_store/**"
 
 module LuckyCacheRedisStore
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/src/lucky_cache_redis_store/cache_item.cr
+++ b/src/lucky_cache_redis_store/cache_item.cr
@@ -1,7 +1,7 @@
 module LuckyCache
   struct CacheItem
     # Preserve the original TTL alongside the absolute expiration restored from Redis.
-    def initialize(@value : CachableTypes, @expires_in : Time::Span, @expiration : Time)
+    def initialize(@value : CacheableTypes, @expires_in : Time::Span, @expiration : Time)
     end
   end
 end

--- a/src/lucky_cache_redis_store/cache_item.cr
+++ b/src/lucky_cache_redis_store/cache_item.cr
@@ -1,0 +1,7 @@
+module LuckyCache
+  struct CacheItem
+    # Preserve the original TTL alongside the absolute expiration restored from Redis.
+    def initialize(@value : CachableTypes, @expires_in : Time::Span, @expiration : Time)
+    end
+  end
+end

--- a/src/lucky_cache_redis_store/redis_store.cr
+++ b/src/lucky_cache_redis_store/redis_store.cr
@@ -21,9 +21,9 @@ module LuckyCache
       data = yield
 
       # For Redis storage, we need to check if the data is serializable
-      # Custom Cachable objects cannot be serialized to JSON without custom serialization logic
+      # Custom Cacheable objects cannot be serialized to JSON without custom serialization logic
       unless serializable?(data)
-        raise ArgumentError.new("RedisStore cannot serialize custom Cachable objects. Use MemoryStore for custom objects or store serializable representations (Hash, NamedTuple, JSON::Any).")
+        raise ArgumentError.new("RedisStore cannot serialize custom Cacheable objects. Use MemoryStore for custom objects or store serializable representations (Hash, NamedTuple, JSON::Any).")
       end
 
       validate_expires_in!(expires_in)
@@ -109,7 +109,7 @@ module LuckyCache
       end
     end
 
-    private def serialize_cache_item(value : CachableTypes, expires_in : Time::Span, expiration : Time) : String
+    private def serialize_cache_item(value : CacheableTypes, expires_in : Time::Span, expiration : Time) : String
       {
         "value"         => serialize_value(value),
         "expires_in_ms" => expires_in.total_milliseconds.to_i64,
@@ -138,7 +138,7 @@ module LuckyCache
       Time::Span.new(nanoseconds: milliseconds * 1_000_000)
     end
 
-    private def serialize_value(value : CachableTypes) : JSON::Any
+    private def serialize_value(value : CacheableTypes) : JSON::Any
       case value
       when Array
         serialize_array_value(value)
@@ -147,7 +147,7 @@ module LuckyCache
       end
     end
 
-    private def serialize_scalar_value(value : CachableTypes) : JSON::Any
+    private def serialize_scalar_value(value : CacheableTypes) : JSON::Any
       case value
       when String
         JSON::Any.new(value)
@@ -187,7 +187,7 @@ module LuckyCache
       end
     end
 
-    private def deserialize_value(json : JSON::Any, type_name : String) : CachableTypes
+    private def deserialize_value(json : JSON::Any, type_name : String) : CacheableTypes
       if type_name.starts_with?("Array(")
         deserialize_array_value(json, type_name)
       else
@@ -195,7 +195,7 @@ module LuckyCache
       end
     end
 
-    private def deserialize_scalar_value(json : JSON::Any, type_name : String) : CachableTypes
+    private def deserialize_scalar_value(json : JSON::Any, type_name : String) : CacheableTypes
       case type_name
       when "String"
         json.as_s
@@ -218,7 +218,7 @@ module LuckyCache
       end
     end
 
-    private def deserialize_array_value(json : JSON::Any, type_name : String) : CachableTypes
+    private def deserialize_array_value(json : JSON::Any, type_name : String) : CacheableTypes
       case type_name
       when "Array(String)"
         json.as_a.map(&.as_s)
@@ -235,7 +235,7 @@ module LuckyCache
       end
     end
 
-    private def determine_type(value : CachableTypes) : String
+    private def determine_type(value : CacheableTypes) : String
       case value
       when Array
         determine_array_type(value)
@@ -244,7 +244,7 @@ module LuckyCache
       end
     end
 
-    private def determine_scalar_type(value : CachableTypes) : String
+    private def determine_scalar_type(value : CacheableTypes) : String
       case value
       when String
         "String"

--- a/src/lucky_cache_redis_store/redis_store.cr
+++ b/src/lucky_cache_redis_store/redis_store.cr
@@ -3,6 +3,8 @@ require "json"
 
 module LuckyCache
   struct RedisStore < BaseStore
+    SCAN_BATCH_SIZE = 100
+
     private getter redis : Redis::Client
     private getter prefix : String
 
@@ -10,12 +12,8 @@ module LuckyCache
     end
 
     def read(key : CacheKey) : CacheItem?
-      prefixed_key = "#{prefix}#{key}"
-
-      if data = redis.get(prefixed_key)
-        if cache_item = deserialize_cache_item(data)
-          cache_item.expired? ? nil : cache_item
-        end
+      if data = redis.get(prefixed_key(key))
+        deserialize_cache_item(data)
       end
     end
 
@@ -28,28 +26,33 @@ module LuckyCache
         raise ArgumentError.new("RedisStore cannot serialize custom Cachable objects. Use MemoryStore for custom objects or store serializable representations (Hash, NamedTuple, JSON::Any).")
       end
 
-      cache_item = CacheItem.new(
-        value: data,
-        expires_in: expires_in
-      )
+      validate_expires_in!(expires_in)
 
-      prefixed_key = "#{prefix}#{key}"
-      serialized = serialize_cache_item(cache_item)
+      expiration = Time.utc + expires_in
+      serialized = serialize_cache_item(data, expires_in, expiration)
 
-      redis.set(prefixed_key, serialized, ex: expires_in.total_seconds.to_i)
+      redis.set(prefixed_key(key), serialized, ex: expires_in)
 
       data
     end
 
     def delete(key : CacheKey)
-      prefixed_key = "#{prefix}#{key}"
-      result = redis.del(prefixed_key)
+      result = redis.del(prefixed_key(key))
       result > 0 ? result : nil
     end
 
     def flush : Nil
-      keys = redis.keys("#{prefix}*").map(&.to_s)
-      redis.del(keys) unless keys.empty?
+      batch = [] of String
+
+      each_prefixed_key do |key|
+        batch << key
+        if batch.size >= SCAN_BATCH_SIZE
+          redis.del(batch)
+          batch.clear
+        end
+      end
+
+      redis.del(batch) unless batch.empty?
     end
 
     def fetch(key : CacheKey, *, as : Array(T).class, expires_in : Time::Span = LuckyCache.settings.default_duration, &) forall T
@@ -74,7 +77,9 @@ module LuckyCache
     end
 
     def size : Int32
-      redis.keys("#{prefix}*").size
+      count = 0
+      each_prefixed_key { count += 1 }
+      count
     end
 
     private def serializable?(value) : Bool
@@ -88,15 +93,28 @@ module LuckyCache
       end
     end
 
-    private def serialize_cache_item(item : CacheItem) : String
-      value_json = serialize_value(item.value)
-      created_at = Time.utc
+    private def prefixed_key(key : CacheKey) : String
+      "#{prefix}#{key}"
+    end
 
+    private def validate_expires_in!(expires_in : Time::Span) : Nil
+      if expires_in.total_milliseconds < 1
+        raise ArgumentError.new("expires_in must be at least 1 millisecond")
+      end
+    end
+
+    private def each_prefixed_key(& : String ->) : Nil
+      redis.scan_each(match: "#{prefix}*", count: SCAN_BATCH_SIZE) do |key|
+        yield key
+      end
+    end
+
+    private def serialize_cache_item(value : CachableTypes, expires_in : Time::Span, expiration : Time) : String
       {
-        "value"      => value_json,
-        "expires_in" => item.expires_in.total_seconds,
-        "created_at" => created_at.to_rfc3339,
-        "type"       => determine_type(item.value),
+        "value"         => serialize_value(value),
+        "expires_in_ms" => expires_in.total_milliseconds.to_i64,
+        "expires_at_ms" => expiration.to_unix_ms,
+        "type"          => determine_type(value),
       }.to_json
     end
 
@@ -105,22 +123,31 @@ module LuckyCache
 
       type_name = parsed["type"].as_s
       value_json = parsed["value"]
-      expires_in = Time::Span.new(seconds: parsed["expires_in"].as_f.to_i)
-      created_at = Time.parse_rfc3339(parsed["created_at"].as_s)
-
-      # Check if expired based on created_at + expires_in
-      if created_at + expires_in < Time.utc
-        return nil
-      end
-
+      expires_in = milliseconds_to_span(parsed["expires_in_ms"].as_i64)
+      expiration = Time.unix_ms(parsed["expires_at_ms"].as_i64)
       value = deserialize_value(value_json, type_name)
 
-      CacheItem.new(value: value, expires_in: expires_in)
+      return nil if expiration <= Time.utc
+
+      CacheItem.new(value, expires_in, expiration)
     rescue
       nil
     end
 
+    private def milliseconds_to_span(milliseconds : Int64) : Time::Span
+      Time::Span.new(nanoseconds: milliseconds * 1_000_000)
+    end
+
     private def serialize_value(value : CachableTypes) : JSON::Any
+      case value
+      when Array
+        serialize_array_value(value)
+      else
+        serialize_scalar_value(value)
+      end
+    end
+
+    private def serialize_scalar_value(value : CachableTypes) : JSON::Any
       case value
       when String
         JSON::Any.new(value)
@@ -138,6 +165,13 @@ module LuckyCache
         JSON::Any.new(value.to_s)
       when JSON::Any
         value
+      else
+        raise ArgumentError.new("Cannot serialize value of type #{value.class}")
+      end
+    end
+
+    private def serialize_array_value(value : Array) : JSON::Any
+      case value
       when Array(String)
         JSON::Any.new(value.map { |v| JSON::Any.new(v) })
       when Array(Int32)
@@ -154,6 +188,14 @@ module LuckyCache
     end
 
     private def deserialize_value(json : JSON::Any, type_name : String) : CachableTypes
+      if type_name.starts_with?("Array(")
+        deserialize_array_value(json, type_name)
+      else
+        deserialize_scalar_value(json, type_name)
+      end
+    end
+
+    private def deserialize_scalar_value(json : JSON::Any, type_name : String) : CachableTypes
       case type_name
       when "String"
         json.as_s
@@ -171,6 +213,13 @@ module LuckyCache
         UUID.new(json.as_s)
       when "JSON::Any"
         json
+      else
+        raise ArgumentError.new("Cannot deserialize type #{type_name}")
+      end
+    end
+
+    private def deserialize_array_value(json : JSON::Any, type_name : String) : CachableTypes
+      case type_name
       when "Array(String)"
         json.as_a.map(&.as_s)
       when "Array(Int32)"
@@ -188,6 +237,15 @@ module LuckyCache
 
     private def determine_type(value : CachableTypes) : String
       case value
+      when Array
+        determine_array_type(value)
+      else
+        determine_scalar_type(value)
+      end
+    end
+
+    private def determine_scalar_type(value : CachableTypes) : String
+      case value
       when String
         "String"
       when Int32
@@ -204,6 +262,13 @@ module LuckyCache
         "UUID"
       when JSON::Any
         "JSON::Any"
+      else
+        "Unknown"
+      end
+    end
+
+    private def determine_array_type(value : Array) : String
+      case value
       when Array(String)
         "Array(String)"
       when Array(Int32)


### PR DESCRIPTION
This shard needed a big refresh.

About luckyframework/lucky_cache#17 : 

This shard already supports those same array/basic types:

  - scalar support in src/lucky_cache_redis_store/redis_store.cr:86
  - array serialization/deserialization in src/lucky_cache_redis_store/redis_store.cr:173, src/
    lucky_cache_redis_store/redis_store.cr:222, and src/lucky_cache_redis_store/redis_store.cr:271
  - regression coverage in spec/lucky_cache_redis_store/redis_store_spec.cr:65 and spec/
    lucky_cache_redis_store/redis_store_spec.cr:137

  The important caveat is that it is not identical to MemoryStore overall:

  - RedisStore still does not support arbitrary custom LuckyCache::Cachable objects.
  - RedisStore also does not support arbitrary Array(Cachable) collections.